### PR TITLE
fix(cmd_rm_branch): 改进针对已rebase分支的'rm all'合并检测

### DIFF
--- a/actions/show_help.sh
+++ b/actions/show_help.sh
@@ -78,6 +78,7 @@ show_help() {
     echo "                              (若不使用 --delete-remotes，删除远程分支前会进行确认，逻辑同上)。"
     echo "                            gw rm all [-f] [--delete-remotes]"
     echo "                              清理所有已合并到 '$MAIN_BRANCH' 的本地分支 (需在主分支运行)。"
+    echo "                              (改进了对 rebase 合并分支的检测能力)"
     echo "                              -f: 强制删除本地分支。"
     echo "                              --delete-remotes: 同时删除所有匹配的远程分支。"
     echo "                            (所有模式下，无法识别的参数将被忽略)"


### PR DESCRIPTION
此前，`gw rm all`使用`git cherry`来检测分支的提交是否存在于主分支中。如果分支是通过rebase集成到主分支的，这种方法可能无法正确识别这些分支为已合并状态，因为即使底层代码更改相同，rebase也会改变提交哈希值。这会导致`gw rm all`无法将这些已rebase的分支列为可删除候选。

本次提交更改了`gw rm all`的合并检测逻辑，改用`git rev-list --count $MAIN_BRANCH..$branch`。现在，如果一个分支没有任何无法从$MAIN_BRANCH到达的提交，则被视为已合并。

这种方法即使在分支已被rebase到主分支的情况下也能正确识别其为已合并状态，使`gw rm all`在以rebase为主的工作流中更加可靠。
