### PR TITLE
feat(actions): 添加 undo 和 unstage 命令

### DIFF
--- a/actions/cmd_undo.sh
+++ b/actions/cmd_undo.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# 脚本/actions/cmd_undo.sh
+
+# 实现 'undo' 命令逻辑，用于撤销上一次提交。
+#
+# 依赖:
+# - core_utils/colors.sh (颜色定义)
+# - core_utils/utils_print.sh (打印函数)
+# - core_utils/utils.sh (通用工具函数)
+
+# Source SCRIPT_DIR if not already sourced
+if [ -z "$SCRIPT_DIR" ]; then
+  export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+source "$SCRIPT_DIR/core_utils/utils.sh"
+source "$SCRIPT_DIR/core_utils/utils_print.sh"
+
+cmd_undo() {
+    if ! check_in_git_repo; then
+        return 1
+    fi
+
+    local mode="mixed" # default
+    local confirm_needed=false
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --soft)
+                mode="soft"
+                shift
+                ;;
+            --hard)
+                mode="hard"
+                confirm_needed=true
+                shift
+                ;;
+            *)
+                print_error "未知选项: $1"
+                show_help_for_command "undo"
+                return 1
+                ;;
+        esac
+    done
+
+    # 检查是否有父提交
+    if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+        print_error "无法撤销：HEAD 没有父提交 (可能是初始提交或仓库为空)。"
+        return 1
+    fi
+
+    if $confirm_needed; then
+        if ! utils_confirm "$(print_warning "警告:") 您确定要永久丢弃上一次提交及其所有更改吗？此操作无法恢复。"; then
+            print_info "操作已取消。"
+            return 0
+        fi
+    fi
+
+    print_step "正在撤销上一次提交 (模式: ${mode})..."
+    case "$mode" in
+        soft)
+            if git reset --soft HEAD~1; then
+                print_success "上一次提交已撤销。更改保留在暂存区。"
+            else
+                print_error "撤销提交失败 (soft reset)。"
+                return 1
+            fi
+            ;;
+        hard)
+            if git reset --hard HEAD~1; then
+                print_success "上一次提交已撤销，相关更改已被永久丢弃。"
+            else
+                print_error "撤销提交失败 (hard reset)。"
+                return 1
+            fi
+            ;;
+        mixed) # default
+            if git reset HEAD~1; then # --mixed is default
+                print_success "上一次提交已撤销。更改已移至您的工作目录 (未暂存)。"
+            else
+                print_error "撤销提交失败 (mixed reset)。"
+                return 1
+            fi
+            ;;
+    esac
+    return 0
+} 

--- a/actions/cmd_unstage.sh
+++ b/actions/cmd_unstage.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# 脚本/actions/cmd_unstage.sh
+
+# 实现 'unstage' 命令逻辑，用于将暂存区的更改移回工作目录。
+#
+# 依赖:
+# - core_utils/colors.sh (颜色定义)
+# - core_utils/utils_print.sh (打印函数)
+# - core_utils/utils.sh (通用工具函数)
+
+# Source SCRIPT_DIR if not already sourced
+if [ -z "$SCRIPT_DIR" ]; then
+  export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+source "$SCRIPT_DIR/core_utils/utils.sh"
+source "$SCRIPT_DIR/core_utils/utils_print.sh"
+
+cmd_unstage() {
+    if ! check_in_git_repo; then
+        return 1
+    fi
+
+    local interactive_mode=false
+    local files_to_unstage=()
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -i | --interactive)
+                interactive_mode=true
+                shift
+                ;;
+            --)
+                shift # Consume '--' separator
+                files_to_unstage+=("$@") # Add all remaining arguments as files
+                break # Stop parsing options
+                ;;
+            -*)
+                print_error "未知选项: $1"
+                show_help_for_command "unstage"
+                return 1
+                ;;
+            *)
+                files_to_unstage+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    if ! git diff --cached --quiet --exit-code; then # Checks if there is anything staged
+        # There are staged changes
+        if $interactive_mode; then
+            if [ ${#files_to_unstage[@]} -gt 0 ]; then
+                print_warning "交互模式下指定文件将被忽略。将对所有暂存的更改进行交互式取消暂存。"
+            fi
+            print_step "进入交互式取消暂存模式..."
+            if git reset -p; then # or git reset --patch
+                print_success "交互式取消暂存完成。"
+            else
+                print_error "交互式取消暂存失败或被中止。"
+                return 1
+            fi
+        elif [ ${#files_to_unstage[@]} -gt 0 ]; then
+            print_step "正在取消暂存指定文件: ${files_to_unstage[*]}..."
+            if git restore --staged -- "${files_to_unstage[@]}"; then
+                print_success "指定文件已取消暂存。"
+            else
+                print_error "取消暂存指定文件失败。请检查文件是否已暂存。"
+                return 1
+            fi
+        else
+            print_step "正在取消暂存所有文件..."
+            if git reset HEAD; then # or git restore --staged .
+                print_success "所有文件已取消暂存。"
+            else
+                print_error "取消暂存所有文件失败。"
+                return 1
+            fi
+        fi
+    else
+        print_info "暂存区为空，无需取消暂存。"
+    fi
+
+    return 0
+} 

--- a/actions/show_help.sh
+++ b/actions/show_help.sh
@@ -46,6 +46,8 @@ show_help() {
     printf "  ${GREEN}%-22s${NC} %s\n" "stash [子命令] [...]" "- 暂存工作区变更 (封装常用 stash 子命令, 对 clear 有确认)。"
     printf "  ${GREEN}%-22s${NC} %s\n" "rebase <目标> [...]" "- Rebase 当前分支 (增强版: 自动更新目标, 处理 stash)。"
     printf "  %-22s  ${GRAY}(支持 -i, --continue, --abort, --skip)${NC}\n" ""
+    printf "  ${GREEN}%-22s${NC} %s\n" "undo [--soft|--hard]" "- 撤销上一次提交。默认放回工作区, --soft 保留暂存, --hard 丢弃。"
+    printf "  ${GREEN}%-22s${NC} %s\n" "unstage [-i] [文件...]" "- 将暂存区更改移回工作区。默认全部, -i 交互, 可指定文件。"
     echo ""
 
     # --- 仓库管理与配置 ---

--- a/git_workflow.sh
+++ b/git_workflow.sh
@@ -42,6 +42,9 @@ shopt -s nullglob
 declare -a action_files=(
     "${SCRIPT_DIR}/actions/cmd_"*.sh
     "${SCRIPT_DIR}/actions/gw_"*.sh
+    # Explicitly add new files if they don't match cmd_* or gw_*
+    # "${SCRIPT_DIR}/actions/cmd_undo.sh" # Already covered by cmd_*.sh
+    # "${SCRIPT_DIR}/actions/cmd_unstage.sh" # Already covered by cmd_*.sh
 )
 if [ -f "${SCRIPT_DIR}/actions/show_help.sh" ]; then
     action_files+=("${SCRIPT_DIR}/actions/show_help.sh")
@@ -249,6 +252,14 @@ main() {
             cmd_rebase "$@"
             LAST_COMMAND_STATUS=$?
             ;;
+        undo)
+            cmd_undo "$@"
+            LAST_COMMAND_STATUS=$?
+            ;;
+        unstage)
+            cmd_unstage "$@"
+            LAST_COMMAND_STATUS=$?
+            ;;
         main|master)
             echo -e "${BLUE}准备推送主分支 ($MAIN_BRANCH)...${NC}"
             cmd_push "$REMOTE_NAME" "$MAIN_BRANCH" "$@"
@@ -309,8 +320,8 @@ main() {
             LAST_COMMAND_STATUS=$?
             ;;
         help|--help|-h)
-            show_help
-            LAST_COMMAND_STATUS=0
+            show_help "$@" # Pass remaining args to help
+            LAST_COMMAND_STATUS=$?
             ;;
         *)
             echo -e "${RED}错误: 未知命令 \"$command\"${NC}"


### PR DESCRIPTION
为 gw 工具集增加两个新的命令：
- `gw undo`: 用于撤销上一次提交。
  - 默认将更改放回工作区。
  - `--soft` 选项将更改保留在暂存区。
  - `--hard` 选项彻底丢弃更改（需确认）。
- `gw unstage`: 用于将暂存区的更改移回工作区。
  - 默认取消所有文件的暂存。
  - 支持指定文件进行取消暂存。
  - `-i` 或 `--interactive` 支持交互式取消暂存。

这两个命令旨在提供更便捷和安全的方式来管理提交和暂存区状态，
减少误操作的风险，并提高开发效率。

相关更新：
- 在 `git_workflow.sh` 中注册了新命令。
- 在 `actions/show_help.sh` 中添加了相应的帮助文档。
